### PR TITLE
Missing "()" in PowerShell command

### DIFF
--- a/Instructions/Labs/MS-700-lab_M02.md
+++ b/Instructions/Labs/MS-700-lab_M02.md
@@ -98,7 +98,7 @@ You are an administrator for your Teams organization. You need to limit which us
 10. Run following cmdlet to check if a Azure AD setting is already existing and load it, if existing. If not, create a blank Azure AD setting object and populate the “$Setting” variable:
 
 	```powershell
-	if (!($Setting=Get-AzureADDirectorySetting|Where {$_.TemplateId -eq $Template.Id})) {$Setting = $Template.CreateDirectorySetting}
+	if (!($Setting=Get-AzureADDirectorySetting|Where {$_.TemplateId -eq $Template.Id})) {$Setting = $Template.CreateDirectorySetting()}
 	```
  
 

--- a/Instructions/Labs/MS-700-lab_M02_ak.md
+++ b/Instructions/Labs/MS-700-lab_M02_ak.md
@@ -118,7 +118,7 @@ You are an administrator for your Teams organization. You need to limit which us
 11. Run following cmdlet to check if a Azure AD setting is already existing and load it, if existing. If not, create a blank Azure AD setting object and populate the “$Setting” variable:
 
 	```powershell
-	if (!($Setting=Get-AzureADDirectorySetting|Where {$_.TemplateId -eq $Template.Id})) {$Setting = $Template.CreateDirectorySetting}
+	if (!($Setting=Get-AzureADDirectorySetting|Where {$_.TemplateId -eq $Template.Id})) {$Setting = $Template.CreateDirectorySetting()}
 	```
 
 12. Run following cmdlet to modify the group creation setting for your tenant with the “EnableGroupCreation” attribute:

--- a/Instructions/Labs/MS-700-lab_M03.md
+++ b/Instructions/Labs/MS-700-lab_M03.md
@@ -295,7 +295,7 @@ Your organization has ordered devices for Microsoft Teams room. In the meantime,
 	Set-CalendarProcessing -Identity "NY-TeamsRoom1" -AutomateProcessing AutoAccept -AddOrganizerToSubject $false -DeleteComments $false -DeleteSubject $false -RemovePrivateProperty $false -AddAdditionalResponse $true -AdditionalResponse "This is a Teams Meeting room"
 	```
  
-6. Disconnect from Exchage Online and end the established session with the following cmdlet:
+6. Disconnect from Exchange Online and end the established session with the following cmdlet:
 
 	```powershell
 	Remove-PSSession $Session

--- a/Instructions/Labs/MS-700-lab_M03_ak.md
+++ b/Instructions/Labs/MS-700-lab_M03_ak.md
@@ -302,7 +302,7 @@ Your organization has ordered devices for Microsoft Teams room. In the meantime,
 	Set-CalendarProcessing -Identity "NY-TeamsRoom1" -AutomateProcessing AutoAccept -AddOrganizerToSubject $false -DeleteComments $false -DeleteSubject $false -RemovePrivateProperty $false -AddAdditionalResponse $true -AdditionalResponse "This is a Teams Meeting room"
 	```
 
-10. Disconnect from Exchage Online and end the established session with the following cmdlet:
+10. Disconnect from Exchange Online and end the established session with the following cmdlet:
 
 	```powershell
 	Remove-PSSession $Session


### PR DESCRIPTION
# Module: 02
## Exercise 01
### Task 02
(Step 10 in Lab, Step 11 in AK)

Changes proposed in this pull request:

-Add ```()``` at end of PowerShell command. see: https://docs.microsoft.com/en-us/microsoft-365/solutions/manage-creation-of-groups?view=o365-worldwide#step-2-run-powershell-commands
