### PR TITLE
Role updates and connectivity tool suggestions.

### DIFF
--- a/Instructions/Labs/MS-700-lab_M01_ak.md
+++ b/Instructions/Labs/MS-700-lab_M01_ak.md
@@ -136,7 +136,7 @@ In this task you will use the default global admin to sign in to the Microsoft 3
 
 11. In the settings below the Account tab, scroll to **Roles** and select **Manage roles** below.
 
-12. When the **Manage roles** pane opens, select **Admin center access** and scroll down to select **Teams service admin**.
+12. When the **Manage roles** pane opens, select **Admin center access** and scroll down to select **Show all by category** to reveal all avaliable roles. Select the **Teams service admin** and **Teams Device Administrator** roles.
 
 13. Select **Save changes** to apply the role. When the **Admin roles updated** message is displayed on the upper part of the pane, close the window of Joni Sherman’s account with the **X** in the upper right to go back to the **Active users** list.
 

--- a/Instructions/Labs/MS-700-lab_M03_ak.md
+++ b/Instructions/Labs/MS-700-lab_M03_ak.md
@@ -180,6 +180,8 @@ You are in the planning phase of a Microsoft Teams deployment. Before deploying 
  
 16. On the **Windows Security Alert** window, select **Allow access**. 
 
+    >**Note:** If you receive a timeout message during the connectivity test, you can select the **Settings** tab in the tool. Adjust the **Connectivity test timeout (seconds)** option to a larger value and then start the test again.
+
 17. When the tests have finished, the symbols below **Connectivity** and **Quality** will turn to green checkmarks in green circles.
 
 18. After the test is **finished**, select the **View Results** tab and review the detailed results of the tests.


### PR DESCRIPTION
### Update to Lab 01 > Exercise 1 > Task 1
With the current lab steps, users can receive errors during the IP phone section in Lab 03 > Exercise 2 > Task 1. Request adds an additional role that is needed for these steps to be successful.

### Update to Lab 03 > Exercise 1 > Task 2
There is a chance that users receive a timeout message during the connectivity test. Added note offers suggestion for correcting the error message.