### PR TITLE
Update MS-700-lab_M01_ak.md

### DIFF
--- a/Instructions/Labs/MS-700-lab_M01_ak.md
+++ b/Instructions/Labs/MS-700-lab_M01_ak.md
@@ -284,37 +284,6 @@ In this task, you will connect with the Teams PowerShell module to your tenant a
 
 You have successfully used the Microsoft Teams PowerShell module to connect to Teams in your tenant and explored some available cmdlets.
   
-#### **Task 3 - Import former Skype for Business Online cmdlets**
-
-Because the Skype for Business Online cmdlets have been integrated into the Teams PowerShell module, a separate module is no longer required, but the cmdlets still need to be in loaded into the Teams PowerShell session. In this task, you will connect to your voice and policy endpoint in your tenant.
-
-1. Connect to the **Client 1 VM** with the credentials that have been provided to you.
-
-2. You have still opened a PowerShell window, and you are still connected to the Microsoft Teams PowerShell module in context of Joni Sherman.
-
-3. Run the following cmdlet to open a new session to the SfBPowerShell endpoint and store the session data to a variable:
- 
-   ```powershell
-   $Session = New-CsOnlineSession
-   ```
-4. After connecting the session, run the following cmdlet to import the new session:
-
-   ```powershell
-   Import-PSSession $Session
-   ```
-5. To view the available cmdlets from the CsOnlineSession module, run the following cmdlet:
-
-   ```powershell
-   Get-Command -Module (Get-Module -Name tmp*)
-   ```
-6. To close the remote PowerShell session, run the following cmdlet:
-
-   ```powershell
-   Remove-PSSession -Session $Session
-   ```
-7. Close the PowerShell window.
-
-You have successfully established a connection to the CsOnline endpoint in your tenant, to manage voice and policy settings that formerly required the independent Skype for Business Online module.
 
 ### **Exercise 3: Create groups and teams**
 


### PR DESCRIPTION
Ex. 2 Task 3. I was unable to run $Session = New-CSOnlineSession as the CS cmdlets are now part of Teams module.
If there is no need import the S4B Online module, why continue to have these labs steps.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-