### PR TITLE
New PowerShell module released

### DIFF
--- a/Instructions/Labs/MS-700-lab_M01.md
+++ b/Instructions/Labs/MS-700-lab_M01.md
@@ -42,8 +42,6 @@ After you complete this lab, you will be able to:
 
 - Install the Teams PowerShell module and explore its cmdlets
 
-- Import the Skype for Business Online PowerShell cmdlets
-
 - Create Microsoft 365 Groups from the M365 admin center
 
 - Create new teams using the Teams Desktop client
@@ -153,7 +151,7 @@ You have successfully explored several available menus from the Teams admin cent
 
 ### **Exercise 2: Explore PowerShell cmdlets for Teams**
 
-In this exercise you will install the Teams and Skype for Business Online PowerShell modules, required to manage teams, policy packages, telephony, and all other settings for Teams in your tenant. You can perform most of the tasks possible from the Teams admin center also in the PowerShell with the two mentioned modules. You can script for automation and even access several settings not available in the GUI.
+In this exercise you will install the Teams PowerShell module, required to manage teams, policy packages, telephony, and all other settings for Teams in your tenant. You can perform most of the tasks possible from the Teams admin center also in the PowerShell. You can script for automation and even access several settings not available in the GUI.
 
 #### **Task 1 - Install Teams PowerShell module**
 
@@ -204,30 +202,6 @@ In this task, you will connect with the Teams PowerShell module to your tenant a
 
 When you are finished with exploring the Microsoft Teams PowerShell cmdlets, close the PowerShell window and continue to the next task.
    
-#### **Task 3 - Import former Skype for Business Online cmdlets**
-
-Because the Skype for Business Online cmdlets have been integrated into the Teams PowerShell, a separate module is no longer required, but the cmdlets still need to be loaded into the Teams PowerShell session. In this task you will connect to your voice and policy endpoint in your tenant.
-
-1. Open a regular **Windows PowerShell** window.
-
-2. Establish a session to the SfBPowerShell:
-
-   ```powershell
-   $Session = New-CsOnlineSession
-   ```
-3. Import the new session:
-
-   ```powershell
-   Import-PSSession $Session
-   ```
-4. Review the modules from the CsOnlineSession module:
-
-   ```powershell
-   Get-Command -Module (Get-Module -Name tmp*)
-   ```
-5. Close the PowerShell window.
-
-You have successfully established a connection to the CsOnline endpoint in your tenant, to manage voice and policy settings that formerly required the independent Skype for Business Online module.
 
 ### **Exercise 3: Create groups and teams**
 

--- a/Instructions/Labs/MS-700-lab_M01_ak.md
+++ b/Instructions/Labs/MS-700-lab_M01_ak.md
@@ -278,43 +278,12 @@ In this task, you will connect with the Teams PowerShell module to your tenant a
    ```powershell
    Get-Help New-Team
    ```
-1. If you receive a message to update the help libraries, type **Y** for yes.
+8. If you receive a message to update the help libraries, type **Y** for yes.
 
-8. When you are finished with exploring the Microsoft Teams PowerShell cmdlets, leave the PowerShell window open and continue to the next task.
+9. When you are finished with exploring the Microsoft Teams PowerShell cmdlets, close the PowerShell window.
 
 You have successfully used the Microsoft Teams PowerShell module to connect to Teams in your tenant and explored some available cmdlets.
-  
-#### **Task 3 - Import former Skype for Business Online cmdlets**
-
-Because the Skype for Business Online cmdlets have been integrated into the Teams PowerShell module, a separate module is no longer required, but the cmdlets still need to be in loaded into the Teams PowerShell session. In this task, you will connect to your voice and policy endpoint in your tenant.
-
-1. Connect to the **Client 1 VM** with the credentials that have been provided to you.
-
-2. You have still opened a PowerShell window, and you are still connected to the Microsoft Teams PowerShell module in context of Joni Sherman.
-
-3. Run the following cmdlet to open a new session to the SfBPowerShell endpoint and store the session data to a variable:
  
-   ```powershell
-   $Session = New-CsOnlineSession
-   ```
-4. After connecting the session, run the following cmdlet to import the new session:
-
-   ```powershell
-   Import-PSSession $Session
-   ```
-5. To view the available cmdlets from the CsOnlineSession module, run the following cmdlet:
-
-   ```powershell
-   Get-Command -Module (Get-Module -Name tmp*)
-   ```
-6. To close the remote PowerShell session, run the following cmdlet:
-
-   ```powershell
-   Remove-PSSession -Session $Session
-   ```
-7. Close the PowerShell window.
-
-You have successfully established a connection to the CsOnline endpoint in your tenant, to manage voice and policy settings that formerly required the independent Skype for Business Online module.
 
 ### **Exercise 3: Create groups and teams**
 

--- a/Instructions/Labs/MS-700-lab_M01_ak.md
+++ b/Instructions/Labs/MS-700-lab_M01_ak.md
@@ -43,8 +43,6 @@ After you complete this lab, you will be able to:
 
 - Install the Teams PowerShell module and explore its cmdlets
 
-- Import the Skype for Business Online PowerShell cmdlets
-
 - Create Microsoft 365 Groups from the M365 admin center
 
 - Create new teams using the Teams Desktop client
@@ -72,6 +70,7 @@ The labs in this course will use two virtual machines:
 **Note:** Lab virtual machine sign in instructions will be provided to you by your instructor.
 
 **Important:** The exercises in the MS-700 labs are cloud-only deployments. A local administrator account has been created on the client VMs. You will log into the VMs as a local administrator instead of a domain account. Following your login, the desktop will indicate that you are logged in as either **CLIENT1\Admin** or **CLIENT2\admin**, depending on which machine you are on.
+
 #### **2. Review installed applications**
 
 Once you signed in to the VM, observe the start menu, and verify following applications have been installed:

--- a/Instructions/Labs/MS-700-lab_M04.md
+++ b/Instructions/Labs/MS-700-lab_M04.md
@@ -64,48 +64,15 @@ You have successfully created a new team with the Teams Desktop client, by using
 
 In this task you will create via the Teams PowerShell a new team **"CA-Office"**. You will create the public channels **"Support"** and **"Recruiting"**. Additionally, you will create the private channel **"Administration"** via Teams PowerShell.
 
-1. Open an elevated **Windows PowerShell (Admin)** window.
+1. Open a **Windows PowerShell** window.
 
-2. Check the Teams PowerShell module for the ability to create private channels:
-
-   ```powershell
-   If((Get-Command New-TeamChannel -ParameterName 'MembershipType' -ErrorAction Ignore) -eq $Null) {"Close PowerShell and install the Teams public preview module."} else {"Continue with the current module."}
-   ```
-   If the output of the command is "**Continue with the current module**", skip steps 3-6 and continue with step 7. If the output of the command is "**Close PowerShell and install the Teams public preview module.**", close the PowerShell window and continue with step 3.
-
-3. If you need to install the Teams public preview module, first open an elevated PowerShell (Admin) window and uninstall the current PowerShell module by running the following cmdlet:
-
-   ```powershell
-   Uninstall-Module MicrosoftTeams
-   ```
-
-   **Note:** If the Uninstall-Module command fails, close the PowerShell window, open a new elevated PowerShell (Admin) window, and then repeat this step.
-
-4. Install PowerShellGet module with the version 2.2.4.1:
-
-   ```powershell
-   Install-Module -Name PowerShellGet -RequiredVersion 2.2.4.1 -Force
-   ```
-
-5. Close and then re-open the elevated PowerShell (Admin) window and then install the Teams PowerShell public preview module:
-
-   ```powershell
-   Install-Module -Name MicrosoftTeams -RequiredVersion 1.1.5-preview -AllowPrerelease -AllowClobber  
-   ```
-
-6. Verify that the Teams PowerShell module supports creating private channels:
-
-   ```powershell
-   If ((Get-Command New-TeamChannel -ParameterName 'MembershipType' -ErrorAction Ignore) -eq $Null) {"Close PowerShell and install the Teams public preview module."} else {"Continue with the current module."}
-   ```
-   
-7. Connect to Teams in your tenant:
+2. Connect to Teams in your tenant:
 
    ```powershell
    Connect-MicrosoftTeams
    ``` 
 
-8. Create a new team with the following settings, using the New-Team cmdlet:
+3. Create a new team with the following settings, using the New-Team cmdlet:
 
 	- Displayname: **CA-Office**
 
@@ -114,13 +81,13 @@ In this task you will create via the Teams PowerShell a new team **"CA-Office"**
 	- Visibility: **Public**
 
 
-9. Use the GroupId from Get-Team and Add-TeamUser to add **Alex Wilbur** and **Allan Deyoung** as members to the team.
+4. Use the GroupId from Get-Team and Add-TeamUser to add **Alex Wilbur** and **Allan Deyoung** as members to the team.
 
-10. Use the GroupId from Get-Team and New-TeamChannel to create the regular channels **"Support"** and **"Recruiting"**.
+5. Use the GroupId from Get-Team and New-TeamChannel to create the regular channels **"Support"** and **"Recruiting"**.
 
-11. Use the GroupId from Get-Team and New-TeamChannel to create the private channel **"Administration"**.
+6. Use the GroupId from Get-Team and New-TeamChannel to create the private channel **"Administration"**.
 
-12. Close the PowerShell window.
+7. Close the PowerShell window.
 
 You have successfully created a team named **CA-Office** with the members Alex Wilber and Allan Deyoung. Joni Sherman is the only team owner. Note that you did not specify any owner in the PowerShell cmdlet and because it was run in context of Joni, she was added as owner automatically. Furthermore, you have created the public channels named **Support** and **Recruiting**, as well as the private channel named **Administration**.
 

--- a/Instructions/Labs/MS-700-lab_M04.md
+++ b/Instructions/Labs/MS-700-lab_M04.md
@@ -42,7 +42,7 @@ After you complete this lab, you will be able to:
 
 #### Task 1 - Create a team from an existing Microsoft 365 Group
 
-As part of your pilot project for Contoso, you need to modify the **"IT-Department"** Microsoft 365 Group, created in an earlier task of this lab, and add Teams features to it.
+As part of your pilot project for Contoso, you need to modify the **"IT-Department"** Microsoft 365 Group, created in an earlier lab, and add Teams features to it.
 
 1. Sign in to the **Teams Desktop client** using **Joni Sherman** (JoniS@&lt;YourTenant&gt;.onmicrosoft.com).
 

--- a/Instructions/Labs/MS-700-lab_M04_ak.md
+++ b/Instructions/Labs/MS-700-lab_M04_ak.md
@@ -43,7 +43,7 @@ After you complete this lab, you will be able to:
 
 #### Task 1 - Create a team from an existing Microsoft 365 Group
 
-As part of your pilot project for Contoso, you need to modify the **"IT-Department"** Microsoft 365 Group, created in an earlier task of this lab, and add Teams features to it.
+As part of your pilot project for Contoso, you need to modify the **"IT-Department"** Microsoft 365 Group, created in an earlier lab, and add Teams features to it.
 
 1. Connect to the **Client 1 VM** with the credentials that have been provided to you.
 

--- a/Instructions/Labs/MS-700-lab_M04_ak.md
+++ b/Instructions/Labs/MS-700-lab_M04_ak.md
@@ -79,105 +79,57 @@ In this task you will create via the Teams PowerShell a new team **"CA-Office"**
 
 2. On the taskbar at the bottom of the page, right click the **Start** button and then select **Windows PowerShell**.
 
-3. Check if the correct version of the MicrosoftTeams module is installed, by using the following cmdlet:
-
-   ```powershell
-   If((Get-Command New-TeamChannel -ParameterName 'MembershipType' -ErrorAction Ignore) -eq $Null) {"Close PowerShell and install the Teams public preview module."} else {"Continue with the current module."}
-   ```
-
-   If the output of the command is "**Close PowerShell and install the Teams public preview module**", close the PowerShell window and continue with the next step. If the output of the command is "**Continue with the current module**", skip steps 5-9 and continue with step 10.
-
-4. If you need to install the Teams public preview module, right click on the Windows symbol in the lower left corner (Start), select **Windows PowerShell (Admin)** and confirm the elevation prompt from the UAC.
-
-5. Uninstall the current Teams PowerShell module by running the following cmdlet:
-
-   ```powershell
-   Uninstall-Module MicrosoftTeams
-   ```
-
-   **Note:** If the Uninstall-Module command fails, close the PowerShell window, open a new elevated PowerShell (Admin) window, and then repeat this step.
-
-6. Next, run the following cmdlet to install PowerShellGet module with the version 2.2.4.1:
-
-   ```powershell
-   Install-Module -Name PowerShellGet -RequiredVersion 2.2.4.1 -Force
-   ```
-
-7. Close the PowerShell window, then reopen it by right selecting on the Windows symbol in the lower left corner (Start), and selecting **Windows PowerShell (Admin)**.
-
-8. Confirm the UAC prompt for elevation with **Yes**.
-
-9. To install the Microsoft Teams PowerShell public preview module, run the following cmdlet and confirm with **y**:
-
-   ```powershell
-   Install-Module -Name MicrosoftTeams -RequiredVersion 1.1.5-preview -AllowPrerelease -AllowClobber 
-   ```
-
-10. Confirm the Untrusted repository message with **y** for yes.
-
-11. After installting, import the Teams PowerShell module with the following cmdlet:
-
-   ```powershell
-   Import-Module MicrosoftTeams
-   ```
-
-12. Verify that the Teams PowerShell module now supports creating private channels by using the following cmdlet:
-
-   ```powershell
-   If((Get-Command New-TeamChannel -ParameterName 'MembershipType' -ErrorAction Ignore) -eq $Null) {"Close PowerShell and install the Teams public preview module."} else {"Continue with the current module."}
-   ```
-
-13. If the correct module is installed and **"Continue with the current module."** is shown, run the following cmdlet to connect to Microsoft Teams in your tenant:
+3. Run the following cmdlet to connect to Microsoft Teams in your tenant:
 
    ```powershell
    Connect-MicrosoftTeams
    ```
 
-14. A **Sign in** dialog box will open. Enter the **UPN** of **Joni Sherman’s** O365 Credentials provided to you (for example, JoniS@&lt;YourTenant&gt;.onmicrosoft.com) and then select **Next**.
+4. A **Sign in** dialog box will open. Enter the **UPN** of **Joni Sherman’s** O365 Credentials provided to you (for example, JoniS@&lt;YourTenant&gt;.onmicrosoft.com) and then select **Next**.
 
-15. In the **Enter password** dialog box, enter the **password** of **Joni Sherman’s** O365 Credentials provided to you and then select **Sign in**.
+5. In the **Enter password** dialog box, enter the **password** of **Joni Sherman’s** O365 Credentials provided to you and then select **Sign in**.
 
-16. Type the following cmdlet to the PowerShell window to create the new team **CA-Office**:
+6. Type the following cmdlet to the PowerShell window to create the new team **CA-Office**:
 
     ```powershell
     New-Team -Displayname "CA-Office" -MailNickName "CA-Office" -Visibility Public
     ```
 
-17. To add the user **Alex Wilber** to the team type the following cmdlet (Replacing **&lt;YourTenant&gt;** with the name of the Microsoft 365 Tenant provided to you.):
+7. To add the user **Alex Wilber** to the team type the following cmdlet (Replacing **&lt;YourTenant&gt;** with the name of the Microsoft 365 Tenant provided to you.):
 
     ```powershell
     Get-Team -Displayname "CA-Office" | Add-TeamUser -User AlexW@<YourTenant>.onmicrosoft.com
     ```
 
-18. To add the user **Allan Deyoung** to the team type the following cmdlet (Replacing **&lt;YourTenant&gt;** with the name of the Microsoft 365 Tenant provided to you.):
+8. To add the user **Allan Deyoung** to the team type the following cmdlet (Replacing **&lt;YourTenant&gt;** with the name of the Microsoft 365 Tenant provided to you.):
 
     ```powershell
     Get-Team -Displayname "CA-Office" | Add-TeamUser -User AllanD@<YourTenant>.onmicrosoft.com
     ```
 
-19. Create a channel **Support** in the **CA-Office** team by using the following cmdlet:
+9. Create a channel **Support** in the **CA-Office** team by using the following cmdlet:
 
     ```powershell
     Get-Team -Displayname "CA-Office" | New-TeamChannel -DisplayName "Support"
     ```
 
-20. Create another channel **Recruiting** in the **CA-Office** team by using the following cmdlet:
+10. Create another channel **Recruiting** in the **CA-Office** team by using the following cmdlet:
 
     ```powershell
     Get-Team -Displayname "CA-Office" | New-TeamChannel -DisplayName "Recruiting"
     ```
 
-21. Create a private channel **Administration** in the **CA-Office** team by using the following cmdlet:
+11. Create a private channel **Administration** in the **CA-Office** team by using the following cmdlet:
 
     ```powershell
     Get-Team -Displayname "CA-Office" | New-TeamChannel -DisplayName "Administration" -MembershipType Private
     ```
 
-22. Close the PowerShell window.
+12. Close the PowerShell window.
 
-23. Open the Teams Desktop Client from the taskbar. On the left side pane with all teams Joni is a member of the new **CA-Office** team, where you can see a private channel below, named "Administration".
+13. Open the Teams Desktop Client from the taskbar. On the left side pane with all teams Joni is a member of the new **CA-Office** team, where you can see a private channel below, named "Administration".
 
-24. Close all browser windows and the Teams Desktop Client.
+14. Close all browser windows and the Teams Desktop Client.
 
 You have successfully created a team named **CA-Office** with the members Alex Wilber and Allan Deyoung. Joni Sherman is the only team owner. Note that you did not specify any owner in the PowerShell cmdlet and because it was run in context of Joni, she was added as owner automatically. Furthermore, you have created the public channels named **Support** and **Recruiting**, as well as the private channel named **Administration**.
 


### PR DESCRIPTION
# Module: 04
## Exercise: 01
### Task: 02

Changes proposed in this pull request:

Teams PowerShell v2 released, SfB connector deprecated. [Microsoft Teams PowerShell Release Notes](https://docs.microsoft.com/en-us/MicrosoftTeams/teams-powershell-release-notes)

- Removed checking for -MembershipType parameter
- Removed uninstall of Teams PowerShell Module
- Removed install of Teams preview module
- Removed incorrect reference to when IT-Department group was created
- Removed Task 3 of Lab 01 referencing SfB PowerShell (more complete removal than pull #48 -those changes included here.)