### PR TITLE
Changes to instructions for clarity and portal changes

### DIFF
--- a/Instructions/Labs/MS-700-lab_M01_ak.md
+++ b/Instructions/Labs/MS-700-lab_M01_ak.md
@@ -314,9 +314,11 @@ You will create the new Microsoft 365 Group named "IT-Department," and then add 
 
 7. Select **Next**.
 
-8. In the Owners field type in the Name of **Joni Sherman**, select her from the **Users** list, and then select **Next**.
+8. In the **Assign Owners** page, select **+Assign owners** then select **Joni Sherman** from the **Users** list and select **Add(1)**, and then select **Next**.
 
-9. As the group email address type in **IT-Department**@&lt;YourTenant&gt;.onmicrosoft.com, set the privacy to **Private – Only members can see group content**, clear the **Create a team for this group** checkbox, and then select **Next**.
+9. In the **Add Members** page, do not make any changes, select **Next**.
+
+10. As the group email address type in **IT-Department**@&lt;YourTenant&gt;.onmicrosoft.com, set the privacy to **Private**, clear the **Create a team for this group** checkbox, and then select **Next**.
 
 10. On the **Review** page, verify the settings and then select **Create group**.
 
@@ -328,9 +330,9 @@ You will create the new Microsoft 365 Group named "IT-Department," and then add 
 
 14. On the **Members** tab, select **View all and manage members**.
 
-15. In the new window, select **+ Add members** from the top and select the checkbox before the following users: **Alex Wilber**, **Allan Deyoung**, **Lynne Robbins**, and **Megan Bowen**.
+15. In the new window, select **+ Add members** from the top and select the checkbox before the following users: **Alex Wilber**, **Allan Deyoung**, **Lynne Robbins**, and **Megan Bowen**, then select **Add (4)**,
 
-16. Select **Save,** then **Close** two times and close the IT-Department pane with the **X**.
+16. Close the IT-Department pane with the **X**.
 
 17. Close the browser window.
 

--- a/Instructions/Labs/MS-700-lab_M02_ak.md
+++ b/Instructions/Labs/MS-700-lab_M02_ak.md
@@ -143,17 +143,17 @@ After activating sensitivity labels for groups, you will now create three sensit
 
 	- **External users access**: Select Let Microsoft 365 group owners add people outside the organization to the group.
 
-14. On the **Define external sharing and device access settings** page select the following setting and then select **Next**.
+14. On the **Define external sharing and device access settings** page select the **Use Azure AD Conditional Access to projtect labeled SharePoint sites** checkbox then select **Allow full access from desktop apps, mobile apps, and the web** and select **Next**.
 
-	- **Unmanaged devices:** Allow full access from desktop apps, mobile apps, and the web.
+15. On the **Auto-labeling for database columns** accept the default setting and select **Next**. 
 
-15. Review your settings and select **Create label** to finish the new label creation.
+16. Review your settings and select **Create label** to finish the new label creation.
 
-16. When the **Your label was created** is displayed, select **Done**.
+17. When the **Your label was created** is displayed, select **Done**.
 
-17. You should now see your newly created label "**General**" on the **Labels** dashboard. Select **+ Create a label** again, to create another sensitivity label.
+18. You should now see your newly created label "**General**" on the **Labels** dashboard. Select **+ Create a label** again, to create another sensitivity label.
 
-18. On the **Name and create a tooltip for your label** page, enter the following information:
+19. On the **Name and create a tooltip for your label** page, enter the following information:
 
 	- **Name**: Internal
 
@@ -163,13 +163,13 @@ After activating sensitivity labels for groups, you will now create three sensit
 
 	- **Description for admins**: Internal information with moderate encryption, marking and sharing restriction settings activated
 
-19. Select **Next**.
+20. Select **Next**.
 
-20. Select **Files &amp; emails** and **Groups &amp; Sites** on the **Define the scope for this label** page and select **Next.**
+21. Select **Files &amp; emails** and **Groups &amp; Sites** on the **Define the scope for this label** page and select **Next.**
 
-21. On the **Choose protection settings for files and emails** page, select both boxes **Encrypt files and emails** and **Mark the content of files** and select **Next**.
+22. On the **Choose protection settings for files and emails** page, select both boxes **Encrypt files and emails** and **Mark the content of files** and select **Next**.
 
-22. On the **Encryption** page, select **configure encryption settings** and perform the following configuration settings:
+23. On the **Encryption** page, select **configure encryption settings** and perform the following configuration settings:
 
 	- Assign permissions now or let users decide: **Assign permissions now**.
 
@@ -177,13 +177,13 @@ After activating sensitivity labels for groups, you will now create three sensit
 
 	- Allow offline access: **Always**.
 
-23. Select **Assign permissions** below **Assign permissions to specific users and groups**.
+24. Select **Assign permissions** below **Assign permissions to specific users and groups**.
 
-24. On the right-side pane, select **+ Add all users and groups in your organization**.
+25. On the right-side pane, select **+ Add all users and groups in your organization**.
 
-25. Select **Save** and **Next** to finish the Encryption settings.
+26. Select **Save** and **Next** to finish the Encryption settings.
 
-26. On the **Content marking** page, select the slider and the checkbox **Add a watermark**.
+27. On the **Content marking** page, select the slider and the checkbox **Add a watermark**.
 
 27. Select **Customize text** to open the right-side pane.
 
@@ -191,7 +191,7 @@ After activating sensitivity labels for groups, you will now create three sensit
 
 29. Select **Save** and **Next**.
 
-30. On the **Auto-labeling for Office apps** page, do not select the slider and select **Next**.
+30. On the **Auto-labeling for files and emails** page, do not select the slider and select **Next**.
 
 31. On the **Define protection settings for groups and sites** page, select both boxes **Privacy and external user access settings** and **External sharing and Conditional Access settings** and select **Next**.
 
@@ -201,11 +201,9 @@ After activating sensitivity labels for groups, you will now create three sensit
 
 	- **External users access**: Leave the box unchecked.
 
-33. On the **external sharing** page, select the following setting and then select **Next**:
+33. On the **Define external sharing and device access settings** page select the **Use Azure AD Conditional Access to projtect labeled SharePoint sites** checkbox then select **Allow limited web-only access** and select **Next**.
 
-	- **Unmanaged devices:** Allow limited, web-only access.
-
-34. Select **Next**.
+34. On the **Atuo-labeling for database columns**, select **Next**.
 
 35. Review your settings and select **Create label** to finish the new label creation.
 
@@ -255,7 +253,7 @@ After activating sensitivity labels for groups, you will now create three sensit
 
 51. Select **Save** and **Next**.
 
-52. On the **Auto-labeling for Office apps** page, do not select the slider and select **Next**.
+52. On the **Auto-labeling for files and emails** page, do not select the slider and select **Next**.
 
 53. On the **Define protection settings for groups and sites** page, check both boxes **Privacy and external user access settings** and **External sharing and Conditional Access settings** and select **Next**.
 
@@ -265,11 +263,9 @@ After activating sensitivity labels for groups, you will now create three sensit
 
 	- **External users access**: Leave the box unchecked.
 
-55. On the **external sharing** page select the following setting and then select **Next**:
+On the **Define external sharing and device access settings** page select the **Use Azure AD Conditional Access to projtect labeled SharePoint sites** checkbox then select **Allow limited, web-only access** and select **Next**.
 
-	- **Unmanaged devices:** Allow limited, web-only access.
-
-56. Select **Next**.
+55. On the **Auto-labeling for database columns** page select **Next**:
 
 57. Review your settings and select **Create label** to finish the new label creation.
 
@@ -279,7 +275,7 @@ After activating sensitivity labels for groups, you will now create three sensit
 
 60. On the **Choose sensitivity labels to publish** page, select **Choose sensitivity labels to publish**.
 
-61. Select the checkbox left from **Select all** and select **Add** to close the right-side pane.
+61. Select the checkbox to the left of **Label** to select all of the labels, and select **Add** to close the right-side pane.
 
 62. Select **Next**.
 
@@ -727,9 +723,9 @@ According to your organization compliance requirements, you need to implement ba
 
 4. In **Microsoft 365 compliance center**, on the left navigation pane, select **Show all** from the bottom of the navigation pane and then select **Data loss prevention**.
 
-5. On the **Data loss prevention** page, select **+ Create policy**.
+5. On the **Data loss prevention** page, select the **Policies** tab, then select **+ Create policy**.
 
-6. On the **Start with a template or create a custom policy** page, select the **Search for specific templates** search box and type: **GDPR**. The **General Data Protection Regulation (GDPR)** template will be preselected. 
+6. On the **Start with a template or create a custom policy** page, select the **Search for specific templates** search box and type: **GDPR**. Select **Privacy** under **Categories**, then select the **General Data Protection Regulation (GDPR)** template from the **Templates** section.
 
 7. Select **Next**
 
@@ -781,7 +777,7 @@ According to your organization compliance requirements, you need to implement ba
 
 	- Select **Override the rule automatically if they report it as false positive**.
 
-14. On the **Test or turn on the policy** page, select **Yes, turn it on right away** and select Next.
+14. On the **Test or turn on the policy** page, select **Turn it on right away** and select Next.
 
 15. On the Review your settings page, review your settings, select **Submit** then **Done**.
 
@@ -835,7 +831,7 @@ After creating a DLP Policy for protecting GDPR relevant data, you will create a
 
 12. From the right-side pane, check the box left of **Credit Card Number** and select **Add**.
 
-13. Leave the high **Accuracy** of 85 to 100 unchanged and do not change the **Instance count** of 1.
+13. Leave the high **High confidence** unchanged and do not change the **Instance count** of 1.
 
 14. Below **Action**, select **+ Add an action** and **Restrict access or encrypt content in Microsoft 365 locations**.
 
@@ -853,7 +849,7 @@ After creating a DLP Policy for protecting GDPR relevant data, you will create a
 
 21. Review the rule settings and select **Next**.
 
-22. Select the radio button **Yes, turn it on right away** and select **Next**.
+22. Select the radio button **Turn it on right away** and select **Next**.
 
 23. Review the policy settings again and select **Submit** then **Done**.
 

--- a/Instructions/Labs/MS-700-lab_M03_ak.md
+++ b/Instructions/Labs/MS-700-lab_M03_ak.md
@@ -339,7 +339,7 @@ Your organization has ordered devices for Microsoft Teams room. In the meantime,
 
 20. In the **Search** box on the right, type **Meeting Room** and then hit Enter.
 
-21. In the results page, locate the **Collaboration and communication** section, and under **Microsoft Teams Rooms Standard** tile, select **Details** and then select **Get free trial**.
+21. In the results page, locate the **Collaboration and communication** section, and under **Microsoft Teams Rooms Standard** tile, select **Details** and then select **Start free trial**.
 
 22. In the **Check out** page, select **Try now**, and in the **order receipt** page, select **Continue**.
 

--- a/Instructions/Labs/MS-700-lab_M05.md
+++ b/Instructions/Labs/MS-700-lab_M05.md
@@ -164,11 +164,11 @@ To avoid administrative overhead with managing large numbers of policies individ
 
 2. Select **Policy packages** and review the existing policy packages.
 
-3. **Edit** the **Messaging policy** of the **Firstline_Worker** package with the following setting:
+3. **Edit** the **Messaging policy** of the **Frontline_Worker** package with the following setting:
 
 	- **Send urgent messages using priority notifications**: On
 
-4. **Edit** the **Calling policy** of the **Firstline_Worker** package with the following settings:
+4. **Edit** the **Calling policy** of the **Frontline_Worker** package with the following settings:
 
 	- **Prevent toll bypass and send calls through the PSTN**: On
 
@@ -176,7 +176,7 @@ To avoid administrative overhead with managing large numbers of policies individ
 
 5. Add **Allan Deyoung** to the policy package.
 
-6. Select **Users** and review the policies for **Allan Dyoung**. You should see **Firstline worker** package and the **Firstline_Worker** policies.
+6. Select **Users** and review the policies for **Allan Dyoung**. You should see **Frontline worker** package and the **Frontline_Worker** policies.
 
 You have successfully modified included policies from an existing policy package and assigned the package to a single user. This will help you assign the same set of policies to a group of users working in the same role or requiring the same access.
 

--- a/Instructions/Labs/MS-700-lab_M05_ak.md
+++ b/Instructions/Labs/MS-700-lab_M05_ak.md
@@ -215,21 +215,21 @@ To avoid administrative overhead with managing large numbers of policies individ
 
 3. In the left-hand navigation pane, select **Policy packages** to display existing policy packages.
 
-4. Review the existing policy packages. Afterwards select **Firstline worker** to edit the policy package.
+4. Review the existing policy packages. Afterwards select **Frontline worker** to edit the policy package.
 
-5. From the list of assigned policies, select **Firstline_Worker** right from **Messaging policy**.
+5. From the list of assigned policies, select **Frontline_Worker** right from **Messaging policy**.
 
 6. Select **Edit** from the upper right corner to change the policy settings.
 
 7. Select the switch right from **Send urgent messages using priority notifications** to **On** and select **Save**.
 
-8. Back on the list of assigned policies, select **Firstline_Worker** right from **Calling policy**.
+8. Back on the list of assigned policies, select **Frontline_Worker** right from **Calling policy**.
 
 9. Select the switch right from **Prevent toll bypass and send calls through the PSTN** and **Busy on busy is available when in a call** to **On** and select **Save**.
 
 10. Back on the list of assigned policies again, select **Back** to go to the Policy packages overview.
 
-11. The checkmark left from the **Firstline worker** policy package is still active. Select **Manage users** from the top pane to open the **Manage users** right-side pane.
+11. The checkmark left from the **Frontline worker** policy package is still active. Select **Manage users** from the top pane to open the **Manage users** right-side pane.
 
 12.  Type "Allan" into the search bar, select **Add** right from **Allan Deyoung** and **Apply**.
 
@@ -237,7 +237,7 @@ To avoid administrative overhead with managing large numbers of policies individ
 
 14. In the line of Allan Deyoung, select **View policies**.
 
-15. Below Assigned policies you can now see the different **Firstline_Worker** policies and below **Policy package** the **Firstline worker** package.
+15. Below Assigned policies you can now see the different **Frontline_Worker** policies and below **Policy package** the **Frontline worker** package.
 
 You have successfully modified included policies from an existing policy package and assigned the package to a single user. This will help you assign the same set of policies to a group of users working in the same role or requiring the same access.
 
@@ -261,9 +261,9 @@ In this task, you will add a custom line of business app required for your compa
 
 6. Select **Apps** from the side pane.
 
-7. Scroll down the list of **Apps**, select **Upload a custom app** and **Upload for Contoso**.
+7. Scroll down the list of **Apps**, select **Upload a custom app** and **Upload for my org**.
 
-8. A file select window appears. Navigate to **Downloads** and select **Notification App.zip**.
+8. A file select window appears. Navigate to **Downloads** and select **Notification App.zip** and select **Open**.
 
 9. Go back to **Apps** from the side pane.
 
@@ -283,11 +283,11 @@ In this task, you will add a custom line of business app required for your compa
 
 17. Go back to **Apps** from the side pane.
 
-18. Scroll down and select **Built for Contoso**.
+18. Scroll down and select **Built for my org**.
 
 19. Select **NotificationBot** and review the details.
 
-20. Select **Add for me**, to test the custom app.
+20. Select **Add for team**, then select **Contoso** from the list of teams, and select **Setup bot**.
 
 21. On the **Welcome to Notification Bot** conversation, select the dropdown menu and select **Weather**, and then select **Show Notification**.
 

--- a/Instructions/Labs/MS-700-lab_M06.md
+++ b/Instructions/Labs/MS-700-lab_M06.md
@@ -78,7 +78,7 @@ In this task you need to sign in to the second client and create a meeting with 
 
 2. Select **Calendar** from the left navigation pane and **Meet Now** from the upper right corner to start a meeting.
 
-3. On the Microsoft Teams page, leave the default settings and select **Join now** button.
+3. On the Microsoft Teams page, select **Computer audio**, leave the other settings at defaults and select **Join now** button.
 
 4. On the Microsoft Team page, hover the mouse over the meeting page, and select the three dots (**…**) **(More actions)**.
 

--- a/Instructions/Labs/MS-700-lab_M06_ak.md
+++ b/Instructions/Labs/MS-700-lab_M06_ak.md
@@ -81,7 +81,7 @@ In this task you need to sign in to the second client and create a meeting with 
 
 3. Select **Calendar** from the left navigation pane and **Meet Now** from the upper right corner to start a meeting.
 
-4. On the Microsoft Teams page, leave the default settings and select **Join now** button.
+4. On the Microsoft Teams page, select **Computer audio** and leave the rest of the settings at the defaults and select **Join now** button.
 
 5. On the Microsoft Team page, hover the mouse over the meeting page, and select the three dots (…) for **More actions**.
 
@@ -321,15 +321,15 @@ As Teams admin, you are responsible for creating the call queue and configuring 
 
 	- Music on hold: **Play default music**
 
-	- Call answering: Select **Add groups** and on the right-side pane, search for **Sales**, select **Add** for **Sales** and then select **Add** at the bottom of the **Add call agents** pane.
+	- Call answering: Select **Choose users and groups** then select **Add groups** and on the right-side pane, search for **Sales**, select **Add** for **Sales** and then select **Add** at the bottom of the **Add call agents** pane.
 
 	- Routing method: **Round robin**
 
 	- Presence-based routing: **Off**
 
-	- Agents can opt out of taking calls: **On**
+	- Call agents can opt out of taking calls: **On**
 
-	- Agent alert time: **30 seconds**
+	- Call agent alert time: **30 seconds**
 
 	- Maximum calls in the queue: **50**
 
@@ -453,11 +453,11 @@ In this task you will activate the Calling Plan Add-on Trial for your tenant so 
 
 4. Open the Navigation Menu in the upper left corner and select  **Billing &gt; purchase services**.
 
-5. Scroll to the bottom of the page and select **Add-ons**.
+5. Select **Add-ons**.
 
-6. Scroll down until you see **Microsoft 365 Domestic Calling Plan Trial** and select **Details**.
+6. Scroll down until you see **Microsoft 365 Domestic Calling Plan for US and Canada Trial** (you may have to select **See more add-ons products**) and select **Details**.
 
-7. Select **Get free trial**.
+7. Select **Start free trial**.
 
 8. Select **Try now** to get 25 Calling Plans for a month.
 
@@ -513,7 +513,7 @@ In this task you will order a phone number to a user with an assigned Calling Pl
 
 11. For **Quantity**  select 1.
 
-12. Select **Next**, then **Finish**.
+12. Select **Next**, **Place order**, then **Finish**.
 
 **Note:** It might take some time for the phone numbers to show up. You can check your order from the **Order history** tab.
 


### PR DESCRIPTION
o	The process for assign owners during the creation of a new group has changed.
o	The process for adding members to an existing group has changed.

•	Module 2 - Lab 2 - Exercise 1: 
o	The process for adding labels has changes in the wizard as well as new pages in the wizard.
o	The wizard for implementing DLP policies has changed.

•	Module 3 - Lab 3 - Exercise 1 
o	It is now termed Start a free trial, no longer get a free trial for the Microsoft Teams Room Standard product.

•	Module 5 - Lab 5 - Exercise 2 
o	The package is Frontline worker, not firstline worker.
o	Task 6 – The PowerApps creation is totally different now, the instructions for task 6 must be completely rewritten to reflect the new PowerApps website.

•	Module 6 - Lab 1 - Exercise 3 
o	When using meet now, you must select audio settings before the Join now button becomes available.
o	The wizard for creating a call queue has changed a little.
o	The process for enabling the M365 Domestic Calling Plan Trial has changed.
[MS700_Change_log_May2021_BillWood.docx](https://github.com/MicrosoftLearning/MS-700-Managing-Microsoft-Teams/files/6534207/MS700_Change_log_May2021_BillWood.docx)

-