### PR TITLE
Update DLP Rule wizard UI reference

### DIFF
--- a/Instructions/Labs/MS-700-lab_M02_ak.md
+++ b/Instructions/Labs/MS-700-lab_M02_ak.md
@@ -612,7 +612,7 @@ According to your organization's compliance requirements, you need to implement 
 
 		- Select **Block users from accessing shared SharePoint, OneDrive, and Teams content**.
 
-		- Select **Block only people outside your organization. Users inside your organization will continue to have access**.
+		- Select **Block only people outside your organization.**.
 
 		- Select **Override the rule automatically if they report it as false positive**.
 


### PR DESCRIPTION
The wizard's UI has changed, and the Custom access and override settings page only references "Block only people outside your organization". Updated the instructions to match the UI.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-