### PR TITLE
Make IT-Department members match lab01

### DIFF
--- a/Instructions/Labs/MS-700-lab_M04_ak.md
+++ b/Instructions/Labs/MS-700-lab_M04_ak.md
@@ -75,7 +75,7 @@ As part of your pilot project for Contoso, you need to modify the **IT-Departmen
 9. Check the team owner and members:
 
 	- Owners: **Joni Sherman**
-	- Members and guests: **Allan Deyoung** and **Alex Wilber**
+	- Members and guests: **Allan Deyoung**, **MOD Administrator**, and **Patti Fernandez**
 
 10. Leave the Teams desktop client open and continue to the next task.
 


### PR DESCRIPTION
Changed to match the membership that was set when the Microsoft 365 group was created in Lab 01.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-