### PR TITLE
Update to match UI

### DIFF
--- a/Instructions/Labs/MS-700-lab_M06_ak.md
+++ b/Instructions/Labs/MS-700-lab_M06_ak.md
@@ -69,7 +69,7 @@ In this task, you will add a new emergency address "One Microsoft Way, Redmond, 
 
       (You can enable **Edit the address manually**, and enter the address manually)
 
-5. Acknowledge the emergency calling disclaimer. An information page opens, either **Print** or **Close** the page and continue to the next task. 
+5. Acknowledge the emergency calling disclaimer. An information page opens, either **Print** or **Cancel** the page and continue to the next task. 
 
 6. Select **Save**.
 


### PR DESCRIPTION
Emergency location disclaimer page is now "Cancel", not "Close".

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-